### PR TITLE
RISC-V: Prohibit relaxing the initial gp generation

### DIFF
--- a/libgloss/riscv/crt0.S
+++ b/libgloss/riscv/crt0.S
@@ -6,8 +6,11 @@
   .global _start
 _start:
   # Initialize global pointer
+.option push
+.option norelax
 1:auipc gp, %pcrel_hi(__global_pointer$)
   addi  gp, gp, %pcrel_lo(1b)
+.option pop
 
   # Clear the bss segment
   la      a0, _edata


### PR DESCRIPTION
I've added an additional linker relaxation that relaxes two instruction
pc-relative sequences to one instruction gp relative sequences when
possible.  This sequence now optimizes the initial gp generation to

  mv gp, gp

which is obviously bogus.  The fix is to disable relaxations when
setting up gp, preventing the linker from relaxing away this setup code.