### PR TITLE
Add symbol type and size for asm code

### DIFF
--- a/libgloss/riscv/crt0.S
+++ b/libgloss/riscv/crt0.S
@@ -4,6 +4,7 @@
 
   .text
   .global _start
+  .type   _start, @function
 _start:
   # Initialize global pointer
 1:auipc gp, %pcrel_hi(__global_pointer$)
@@ -25,10 +26,15 @@ _start:
   li      a2, 0                      # a2 = envp = NULL
   call    main
   tail    exit
+  .size  _start, .-_start
 
   .global _init
+  .type   _init, @function
   .global _fini
+  .type   _fini, @function
 _init:
 _fini:
   # These don't have to do anything since we use init_array/fini_array.
   ret
+  .size  _init, .-_init
+  .size  _fini, .-_fini

--- a/newlib/libc/machine/riscv/memset.S
+++ b/newlib/libc/machine/riscv/memset.S
@@ -1,5 +1,6 @@
 .text
 .global memset
+.type	memset, @function
 memset:
   li a6, 15
   move a4, a0
@@ -83,3 +84,4 @@ memset:
   add a2, a2, a5
   bleu a2, a6, .Ltiny
   j .Laligned
+  .size	memset, .-memset

--- a/newlib/libc/machine/riscv/setjmp.S
+++ b/newlib/libc/machine/riscv/setjmp.S
@@ -2,6 +2,7 @@
 
 /* int setjmp (jmp_buf);  */
   .globl  setjmp
+  .type   setjmp, @function
 setjmp:
 	REG_S ra,  0*SZREG(a0)
 	REG_S s0,  1*SZREG(a0)
@@ -35,9 +36,11 @@ setjmp:
 
 	li    a0, 0
 	ret
+	.size	setjmp, .-setjmp
 
 /* volatile void longjmp (jmp_buf, int);  */
   .globl  longjmp
+  .type   longjmp, @function
 longjmp:
 	REG_L ra,  0*SZREG(a0)
 	REG_L s0,  1*SZREG(a0)
@@ -72,3 +75,4 @@ longjmp:
 	seqz a0, a1
 	add  a0, a0, a1   # a0 = (a1 == 0) ? 1 : a1
 	ret
+	.size	longjmp, .-longjmp

--- a/newlib/libc/machine/riscv/strcmp.S
+++ b/newlib/libc/machine/riscv/strcmp.S
@@ -6,6 +6,7 @@
 
 .text
 .globl strcmp
+.type  strcmp, @function
 strcmp:
   or    a4, a0, a1
   li    t2, -1
@@ -126,6 +127,7 @@ strcmp:
   foundnull 1 3
   foundnull 2 3
 #endif
+.size	strcmp, .-strcmp
 
 #if SZREG == 8
 .section .srodata.cst8,"aM",@progbits,8


### PR DESCRIPTION
Testsuite result:
```
                                    |  rv64imafdc   |  rv32imafdc   |    rv64imac   |    rv32imac   | 
gcc       # of expected failures    |         146   |         147   |         146   |         147   | 
          # of expected passes      |       87675   |       86688   |       87670   |       86683   | 
          # of unexpected failures  |           1   |           1   |           1   |           1   | 
          # of unexpected successes |           3   |           2   |           3   |           2   | 
          # of unsupported tests    |        2197   |        2388   |        2199   |        2390   | 
g++       # of expected failures    |         312   |         312   |         312   |         312   | 
          # of expected passes      |       91198   |       89316   |       91198   |       89316   | 
          # of unexpected failures  |           0   |           0   |           0   |           0   | 
          # of unexpected successes |           0   |           0   |           0   |           0   | 
          # of unsupported tests    |        4534   |        4562   |        4534   |        4562   | 

```