### PR TITLE
Fix libnosys build for RISC-V

### DIFF
--- a/libgloss/libnosys/configure
+++ b/libgloss/libnosys/configure
@@ -2031,6 +2031,8 @@ case "${target}" in
 	;;
   mn10?00-*-*)
 	;;
+  riscv*-*-*)
+	;;
   powerpcle-*-pe)
 	;;
   sh*-*-*)

--- a/libgloss/libnosys/configure.in
+++ b/libgloss/libnosys/configure.in
@@ -65,6 +65,8 @@ case "${target}" in
 	;;
   mn10?00-*-*)
 	;;
+  riscv*-*-*)
+	;;
   powerpcle-*-pe)
 	;;
   sh*-*-*)


### PR DESCRIPTION
It seems I don't make libnosys built correctly before, it's still generate syscall wrapper without underscore.