### PR TITLE
Bring signal.h up to date with mainline newlib. 

### DIFF
--- a/newlib/libc/include/sys/signal.h
+++ b/newlib/libc/include/sys/signal.h
@@ -18,9 +18,11 @@ extern "C" {
 typedef	__sigset_t	sigset_t;
 #endif
 
-#if defined(__rtems__)
+#if defined(__CYGWIN__)
+#include <cygwin/signal.h>
+#else
 
-#if defined(_POSIX_REALTIME_SIGNALS)
+#if defined(_POSIX_REALTIME_SIGNALS) || __POSIX_VISIBLE >= 199309
 
 /* sigev_notify values
    NOTE: P1003.1c/D10, p. 34 adds SIGEV_THREAD.  */
@@ -68,7 +70,9 @@ typedef struct {
   int          si_code;     /* Cause of the signal */
   union sigval si_value;    /* Signal value */
 } siginfo_t;
-#endif
+#endif /* defined(_POSIX_REALTIME_SIGNALS) || __POSIX_VISIBLE >= 199309 */
+
+#if defined(__rtems__)
 
 /*  3.3.8 Synchronously Accept a Signal, P1003.1b-1993, p. 76 */
 
@@ -108,9 +112,8 @@ struct sigaction {
 #define sa_sigaction  _signal_handlers._sigaction
 #endif
 
-#elif defined(__CYGWIN__)
-#include <cygwin/signal.h>
-#else
+#else /* defined(__rtems__) */
+
 #define SA_NOCLDSTOP 1  /* only value supported now for sa_flags */
 
 typedef void (*_sig_func_ptr)(int);
@@ -122,6 +125,7 @@ struct sigaction
 	int sa_flags;
 };
 #endif /* defined(__rtems__) */
+#endif /* defined(__CYGWIN__) */
 
 #if __BSD_VISIBLE || __XSI_VISIBLE >= 4 || __POSIX_VISIBLE >= 200809
 /*
@@ -152,13 +156,15 @@ typedef struct sigaltstack {
   size_t    ss_size;  /* Stack size.  */
 } stack_t;
 
+#if __POSIX_VISIBLE
 #define SIG_SETMASK 0	/* set mask with sigprocmask() */
 #define SIG_BLOCK 1	/* set of signals to block */
 #define SIG_UNBLOCK 2	/* set of signals to, well, unblock */
 
 int _EXFUN(sigprocmask, (int how, const sigset_t *set, sigset_t *oset));
+#endif
 
-#if defined(_POSIX_THREADS)
+#if __POSIX_VISIBLE >= 199506
 int _EXFUN(pthread_sigmask, (int how, const sigset_t *set, sigset_t *oset));
 #endif
 
@@ -168,10 +174,14 @@ int _EXFUN(_kill, (pid_t, int));
 #endif /* _COMPILING_NEWLIB */
 #endif /* __CYGWIN__ || __rtems__ */
 
+#if __POSIX_VISIBLE
 int _EXFUN(kill, (pid_t, int));
+#endif
 
 #if __BSD_VISIBLE || __XSI_VISIBLE >= 4
 int _EXFUN(killpg, (pid_t, int));
+#endif
+#if __POSIX_VISIBLE
 int _EXFUN(sigaction, (int, const struct sigaction *, struct sigaction *));
 int _EXFUN(sigaddset, (sigset_t *, const int));
 int _EXFUN(sigdelset, (sigset_t *, const int));
@@ -180,7 +190,7 @@ int _EXFUN(sigfillset, (sigset_t *));
 int _EXFUN(sigemptyset, (sigset_t *));
 int _EXFUN(sigpending, (sigset_t *));
 int _EXFUN(sigsuspend, (const sigset_t *));
-int _EXFUN(sigpause, (int));
+int _EXFUN(sigwait, (const sigset_t *set, int *sig));
 
 #if !defined(__CYGWIN__) && !defined(__rtems__)
 /* These depend upon the type of sigset_t, which right now 
@@ -192,17 +202,33 @@ int _EXFUN(sigpause, (int));
 #define sigfillset(what)    (*(what) = ~(0), 0)
 #define sigismember(what,sig) (((*(what)) & (1<<(sig))) != 0)
 #endif /* !__CYGWIN__ && !__rtems__ */
-#endif /* __BSD_VISIBLE || __XSI_VISIBLE >= 4 */
+#endif /* __POSIX_VISIBLE */
+
+/* There are two common sigpause variants, both of which take an int argument.
+   If you request _XOPEN_SOURCE or _GNU_SOURCE, you get the System V version,
+   which removes the given signal from the process's signal mask; otherwise
+   you get the BSD version, which sets the process's signal mask to the given
+   value. */
+#if __XSI_VISIBLE && !defined(__INSIDE_CYGWIN__)
+# ifdef __GNUC__
+int _EXFUN(sigpause, (int)) __asm__ (__ASMNAME ("__xpg_sigpause"));
+# else
+int _EXFUN(__xpg_sigpause, (int));
+#  define sigpause __xpg_sigpause
+# endif
+#elif __BSD_VISIBLE
+int _EXFUN(sigpause, (int));
+#endif
 
 #if __BSD_VISIBLE || __XSI_VISIBLE >= 4 || __POSIX_VISIBLE >= 200809
 int _EXFUN(sigaltstack, (const stack_t *__restrict, stack_t *__restrict));
 #endif
 
-#if defined(_POSIX_THREADS)
+#if __POSIX_VISIBLE >= 199506
 int _EXFUN(pthread_kill, (pthread_t thread, int sig));
 #endif
 
-#if defined(_POSIX_REALTIME_SIGNALS)
+#if __POSIX_VISIBLE >= 199309
 
 /*  3.3.8 Synchronously Accept a Signal, P1003.1b-1993, p. 76
     NOTE: P1003.1c/D10, p. 39 adds sigwait().  */
@@ -211,12 +237,10 @@ int _EXFUN(sigwaitinfo, (const sigset_t *set, siginfo_t *info));
 int _EXFUN(sigtimedwait,
   (const sigset_t *set, siginfo_t *info, const struct timespec  *timeout)
 );
-int _EXFUN(sigwait, (const sigset_t *set, int *sig));
-
 /*  3.3.9 Queue a Signal to a Process, P1003.1b-1993, p. 78 */
 int _EXFUN(sigqueue, (pid_t pid, int signo, const union sigval value));
 
-#endif /* defined(_POSIX_REALTIME_SIGNALS) */
+#endif /* __POSIX_VISIBLE >= 199309 */
 
 #if defined(___AM29K__)
 /* These all need to be defined for ANSI C, but I don't think they are


### PR DESCRIPTION
There is a bug that siginfo_t is not defined (because of improper guards), but it is referenced in signal.h.