### PR TITLE
Add gdb sim and newlib nano support.  Fix a few misc minor bugs.

### DIFF
--- a/libgloss/riscv/Makefile.in
+++ b/libgloss/riscv/Makefile.in
@@ -40,6 +40,9 @@ gloss_srcs = \
 	sys_wait.c \
 	sys_write.c 
 
+gloss_specs = \
+	nano.specs sim.specs
+
 # Extra files
 
 crt0_asm      = crt0.S
@@ -117,7 +120,7 @@ gloss_c_deps = $(patsubst %.c, %.d, $(notdir $(gloss_c_srcs)))
 $(gloss_c_objs) : %.o : %.c
 	$(COMPILE) -c $<
 
-objs += $(gloss_c_objs)
+gloss_objs += $(gloss_c_objs)
 deps += $(gloss_c_deps)
 junk += $(gloss_c_deps) $(gloss_c_objs)
 
@@ -132,7 +135,7 @@ gloss_asm_deps = $(patsubst %.S, %.d, $(notdir $(gloss_asm_srcs)))
 $(gloss_asm_objs) : %.o : %.S
 	$(COMPILE) -c $<
 
-objs += $(gloss_asm_objs)
+gloss_objs += $(gloss_asm_objs)
 deps += $(gloss_asm_deps)
 junk += $(gloss_asm_deps) $(gloss_asm_objs)
 
@@ -141,14 +144,37 @@ junk += $(gloss_asm_deps) $(gloss_asm_objs)
 #-------------------------------------------------------------------------
 
 gloss_lib  = libgloss.a
-$(gloss_lib) : $(objs)
+$(gloss_lib) : $(gloss_objs)
 	$(AR) rcv $@ $^
 	$(RANLIB) $@
 
-junk += $(gloss_libs)
+junk += $(gloss_lib)
 
 install_hdrs += $(gloss_hdrs)
 install_libs += $(gloss_lib)
+install_specs += $(gloss_specs)
+
+#-------------------------------------------------------------------------
+# Build libsim.a
+#-------------------------------------------------------------------------
+
+sbrk.o: $(src_dir)/../sbrk.c
+	$(COMPILE) -c $<
+sim-syscalls.o: syscalls.c
+	$(COMPILE) -c -DUSING_SIM_SPECS -o $@ $<
+
+sim_c_objs = sbrk.o sim-syscalls.o
+sim_c_deps = $(patsubst %.o, %.d, $(notdir $(sim_c_objs)))
+
+sim_lib  = libsim.a
+$(sim_lib) : $(sim_c_objs)
+	$(AR) rcv $@ $^
+	$(RANLIB) $@
+
+deps += $(sim_c_deps)
+junk += $(sim_lib) $(sim_c_objs) $(sim_c_deps)
+
+install_libs += $(sim_lib)
 
 #-------------------------------------------------------------------------
 # Build crt0.o
@@ -191,7 +217,13 @@ install-libs : $(install_libs)
 		$(INSTALL_DATA) $$file $(install_libs_dir)/$$file; \
 	done
 
-install : install-hdrs install-libs 
+install-specs : $(install_specs)
+	test -d $(install_libs_dir) || mkdir -p $(install_libs_dir)
+	for file in $^; do \
+		$(INSTALL_DATA) $$file $(install_libs_dir)/; \
+	done
+
+install : install-hdrs install-libs install-specs
 .PHONY : install install-hdrs install-libs
 
 #-------------------------------------------------------------------------

--- a/libgloss/riscv/Makefile.in
+++ b/libgloss/riscv/Makefile.in
@@ -124,6 +124,16 @@ gloss_objs += $(gloss_c_objs)
 deps += $(gloss_c_deps)
 junk += $(gloss_c_deps) $(gloss_c_objs)
 
+sim_c_objs = $(patsubst %.c, sim-%.o, $(notdir $(gloss_c_srcs)))
+sim_c_deps = $(patsubst %.c, sim-%.d, $(notdir $(gloss_c_srcs)))
+
+$(sim_c_objs): sim-%.o : %.c
+	$(COMPILE) -c -DUSING_SIM_SPECS -o $@ $<
+
+sim_objs += $(sim_c_objs)
+deps += $(sim_c_deps)
+junk += $(sim_c_deps) $(sim_c_objs)
+
 #-------------------------------------------------------------------------
 # Build Object Files from Assembly Source
 #-------------------------------------------------------------------------
@@ -133,11 +143,21 @@ gloss_asm_objs = $(patsubst %.S, %.o, $(notdir $(gloss_asm_srcs)))
 gloss_asm_deps = $(patsubst %.S, %.d, $(notdir $(gloss_asm_srcs)))
 
 $(gloss_asm_objs) : %.o : %.S
-	$(COMPILE) -c $<
+	$(COMPILE) -c -o $@ $<
 
 gloss_objs += $(gloss_asm_objs)
 deps += $(gloss_asm_deps)
 junk += $(gloss_asm_deps) $(gloss_asm_objs)
+
+sim_asm_objs = $(patsubst %.S, sim-%.o, $(notdir $(gloss_asm_srcs)))
+sim_asm_deps = $(patsubst %.S, sim-%.d, $(notdir $(gloss_asm_srcs)))
+
+$(sim_asm_objs) : sim-%.o : %.S
+	$(COMPILE) -c -DUSING_SIM_SPECS -o $@ $<
+
+sim_objs += $(sim_asm_objs)
+deps += $(sim_asm_deps)
+junk += $(sim_asm_deps) $(sim_asm_objs)
 
 #-------------------------------------------------------------------------
 # Build libgloss.a
@@ -158,21 +178,12 @@ install_specs += $(gloss_specs)
 # Build libsim.a
 #-------------------------------------------------------------------------
 
-sbrk.o: $(src_dir)/../sbrk.c
-	$(COMPILE) -c $<
-sim-syscalls.o: syscalls.c
-	$(COMPILE) -c -DUSING_SIM_SPECS -o $@ $<
-
-sim_c_objs = sbrk.o sim-syscalls.o
-sim_c_deps = $(patsubst %.o, %.d, $(notdir $(sim_c_objs)))
-
 sim_lib  = libsim.a
-$(sim_lib) : $(sim_c_objs)
+$(sim_lib) : $(sim_objs)
 	$(AR) rcv $@ $^
 	$(RANLIB) $@
 
-deps += $(sim_c_deps)
-junk += $(sim_lib) $(sim_c_objs) $(sim_c_deps)
+junk += $(sim_lib)
 
 install_libs += $(sim_lib)
 

--- a/libgloss/riscv/nano.specs
+++ b/libgloss/riscv/nano.specs
@@ -1,0 +1,23 @@
+%rename link                nano_link
+%rename link_gcc_c_sequence                nano_link_gcc_c_sequence
+%rename cpp		nano_cpp
+
+*cpp:
+-isystem =/include/newlib-nano %(nano_cpp)
+
+*nano_libc:
+-lc_nano
+
+*nano_libgloss:
+%{specs=nosys.specs:-lnosys} %{!specs=nosys.specs:-lgloss_nano}
+
+*link_gcc_c_sequence:
+%(nano_link_gcc_c_sequence) --start-group %G %(nano_libc) %(nano_libgloss) --end-group
+
+*link:
+%(nano_link) %:replace-outfile(-lc -lc_nano) %:replace-outfile(-lg -lg_nano)
+
+*lib:
+%{!shared:%{g*:-lg_nano} %{!p:%{!pg:-lc_nano}}%{p:-lc_p}%{pg:-lc_p}}
+
+# ??? Maybe put --gc-sections option in here?

--- a/libgloss/riscv/sim.specs
+++ b/libgloss/riscv/sim.specs
@@ -1,3 +1,5 @@
+# Spec file for gdb simulator.
+
 %rename lib	sim_lib
 %rename link	sim_link
 

--- a/libgloss/riscv/sim.specs
+++ b/libgloss/riscv/sim.specs
@@ -1,0 +1,8 @@
+%rename lib	sim_lib
+%rename link	sim_link
+
+*lib:
+--start-group -lc -lsim --end-group
+
+*link:
+%(sim_link) %:replace-outfile(-lgloss -lsim)

--- a/libgloss/riscv/sys_sbrk.c
+++ b/libgloss/riscv/sys_sbrk.c
@@ -1,3 +1,31 @@
+#ifdef USING_SIM_SPECS
+
+// Gdb simulator requires that sbrk be implemented without a syscall.
+extern char _end[];                /* _end is set in the linker command file */
+char *heap_ptr;
+
+/*
+ * sbrk -- changes heap size size. Get nbytes more
+ *         RAM. We just increment a pointer in what's
+ *         left of memory on the board.
+ */
+char *
+_sbrk (nbytes)
+     int nbytes;
+{
+  char        *base;
+
+  if (!heap_ptr)
+    heap_ptr = (char *)&_end;
+  base = heap_ptr;
+  heap_ptr += nbytes;
+
+  return base;
+}
+
+#else
+
+// QEMU uses a syscall.
 #include <machine/syscall.h>
 
 //----------------------------------------------------------------------
@@ -27,4 +55,4 @@ _sbrk(ptrdiff_t incr)
   heap_end += incr;
   return (void *)(heap_end - incr);
 }
-
+#endif


### PR DESCRIPTION
	libgloss/
	* riscv/Makefile.in (gloss_specs, install_specs, sbrk.o)
	(sim-syscalls.o, sim_c_objs, sim_c_deps, sim_lib): New.
	(gloss_objs): Renamed from objs.
	(gloss_lib): Change objs to gloss_objs.
	(junk): Change gloss_libs to glass_lib.  Add sim_lib, sim_c_objc,
	sim_c_deps.
	(deps): Add sim_c_deps.
	(install_libs): Add sim_lib.
	(install): Add install-specs.
	* riscv/nano.specs: New.
	* riscv/sim.specs: New.
	* riscv/syscalls.c (sbrk): Put inside USING_SIM_SPECS ifndef.