### PR TITLE
2 minor fix for newlib

### DIFF
--- a/libgloss/riscv/sys_isatty.c
+++ b/libgloss/riscv/sys_isatty.c
@@ -14,6 +14,6 @@ _isatty(int file)
 {
   struct stat s;
   int ret = _fstat (file, &s);
-  return ret == -1 ? -1 : !!(s.st_mode & S_IFCHR);
+  return ret == -1 ? 0 : !!(s.st_mode & S_IFCHR);
 }
 

--- a/newlib/libc/include/machine/setjmp.h
+++ b/newlib/libc/include/machine/setjmp.h
@@ -359,7 +359,9 @@ _BEGIN_STD_C
 #endif
 
 #ifdef __riscv
-#define _JBTYPE long
+/* _JBTYPE using long long to make sure the alignment is align to 8 byte,
+   otherwise in rv32imafd, store/restor FPR may mis-align.  */
+#define _JBTYPE long long
 #ifdef __riscv_32e
 #define _JBLEN ((4*sizeof(long))/sizeof(long))
 #else


### PR DESCRIPTION
- rv32imafd may misaligned on jmp_buf due to `fld`/`fsd`  required 8 byte-align 
- isatty should return 0 on return [1]

[1] https://linux.die.net/man/3/isatty