### PR TITLE
Added optional support for external pthreads library via --enable-riscv-pthreads

### DIFF
--- a/newlib/acconfig.h
+++ b/newlib/acconfig.h
@@ -9,6 +9,9 @@
 /* Newlib version */
 #undef _NEWLIB_VERSION
 
+/* pthreads support in header files for newlib */
+#undef _WANT_RISCV_PTHREADS
+
 /* C99 formats support (such as %a, %zu, ...) in IO functions like
  * printf/scanf enabled */
 #undef _WANT_IO_C99_FORMATS

--- a/newlib/configure
+++ b/newlib/configure
@@ -782,6 +782,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_riscv_pthreads
 enable_newlib_io_pos_args
 enable_newlib_io_c99_formats
 enable_newlib_register_fini
@@ -1453,6 +1454,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-riscv-pthreads   enable pthreads support for riscv bare metal
   --enable-newlib-io-pos-args enable printf-family positional arg support
   --enable-newlib-io-c99-formats   enable C99 support in IO functions like printf/scanf
   --enable-newlib-register-fini   enable finalization function registration using atexit
@@ -2235,6 +2237,16 @@ ac_config_sub="$SHELL $ac_aux_dir/config.sub"  # Please don't use this var.
 ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
+# Check whether --enable-riscv-pthreads was given.
+if test "${enable_riscv_pthreads+set}" = set; then :
+  enableval=$enable_riscv_pthreads; case "${enableval}" in
+  yes) riscv_pthreads=yes;;
+  no)  riscv_pthreads=no ;;
+  *)   as_fn_error $? "bad value ${enableval} for riscv-pthreads option" "$LINENO" 5 ;;
+ esac
+else
+  riscv_pthreads=
+fi
 
 # Check whether --enable-newlib-io-pos-args was given.
 if test "${enable_newlib_io_pos_args+set}" = set; then :
@@ -12287,6 +12299,13 @@ fi
 if test "${newlib_elix_level}" -gt "0"; then
 cat >>confdefs.h <<_ACEOF
 #define _ELIX_LEVEL ${newlib_elix_level}
+_ACEOF
+
+fi
+
+if test "${riscv_pthreads}" = "yes"; then
+cat >>confdefs.h <<_ACEOF
+#define _WANT_RISCV_PTHREADS 1
 _ACEOF
 
 fi

--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -217,7 +217,8 @@ case "${host_cpu}" in
   riscv*)
   	libm_machine_dir=riscv
 	machine_dir=riscv
-	newlib_cflags="${newlib_cflags} -DHAVE_NANOSLEEP"
+	newlib_cflags="${newlib_cflags} -DHAVE_NANOSLEEP -D_COMPILING_NEWLIB"
+	default_riscv_pthreads="no"
 	default_newlib_atexit_dynamic_alloc="no"
 	;;
   mips*)
@@ -867,6 +868,13 @@ case "${host}" in
 esac
 
 # Use defaults for certain settings if not specified by user
+
+# Enable pthreads for RISCV if requested. [still need to link libpthread.a]
+if [ "x${riscv_pthreads}" = "x" ]; then
+       if [ ${default_riscv_pthreads} = "yes" ]; then
+               riscv_pthreads="yes";
+       fi
+fi
 
 # Enable C99 format support in I/O routines if requested.
 if [ "x${newlib_io_c99_formats}" = "x" ]; then

--- a/newlib/configure.in
+++ b/newlib/configure.in
@@ -9,6 +9,15 @@ AC_CONFIG_HEADERS([_newlib_version.h:_newlib_version.hin newlib.h:newlib.hin])
 dnl Can't be done in NEWLIB_CONFIGURE because that confuses automake. 
 AC_CONFIG_AUX_DIR(..)
 
+dnl Support --enable-riscv-pthreads
+AC_ARG_ENABLE(riscv-pthreads,
+[  --enable-riscv-pthreads   enable pthreads support for riscv bare metal],
+[case "${enableval}" in
+  yes) riscv_pthreads=yes;;
+  no)  riscv_pthreads=no ;;
+  *)   AC_MSG_ERROR(bad value ${enableval} for riscv-pthreads option) ;;
+ esac], [riscv_pthreads=])dnl
+
 dnl Support --enable-newlib-io-pos-args
 dnl This option is actually read in libc/configure.in.  It is repeated
 dnl here so that it shows up in the help text.
@@ -363,6 +372,10 @@ AC_SUBST(CC_FOR_BUILD)
 
 if test "${newlib_elix_level}" -gt "0"; then
 AC_DEFINE_UNQUOTED(_ELIX_LEVEL,${newlib_elix_level})
+fi
+
+if test "${riscv_pthreads}" = "yes"; then
+AC_DEFINE_UNQUOTED(_WANT_RISCV_PTHREADS)
 fi
 
 if test "${newlib_io_c99_formats}" = "yes"; then

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -26,6 +26,7 @@ extern "C" {
 #endif
 
 #include <_newlib_version.h>
+#include <newlib.h>
 
 /* Macro to test version of GCC.  Returns 0 for non-GCC or too old GCC. */
 #ifndef __GNUC_PREREQ
@@ -313,6 +314,25 @@ extern "C" {
 #else
 #define	__XSI_VISIBLE		0
 #endif
+
+/* RISCV Pthreads */
+#ifdef _WANT_RISCV_PTHREADS
+
+/* Tell we have POSIX threads.  */
+#define _POSIX_THREADS  1
+#define _POSIX_REENTRANT_FUNCTIONS      1
+#define _POSIX_THREAD_SAFE_FUNCTIONS    1
+#define _POSIX_THREAD_ATTR_STACKSIZE    1
+#define _POSIX_THREAD_ATTR_STACKADDR    1
+#define _POSIX_SEMAPHORES       0
+#define _POSIX_BARRIERS                 200112L
+#define _POSIX_READER_WRITER_LOCKS      200112L
+#define _POSIX_SPIN_LOCKS               200112L
+#define _POSIX_TIMERS			1
+/* this is for recursive mutexes */
+#define _UNIX98_THREAD_MUTEX_ATTRIBUTES         1
+
+#endif /* _WANT_RISCV_PTHREADS */
 
 /* RTEMS adheres to POSIX -- 1003.1b with some features from annexes.  */
 

--- a/newlib/libc/machine/riscv/Makefile.am
+++ b/newlib/libc/machine/riscv/Makefile.am
@@ -8,7 +8,7 @@ AM_CCASFLAGS = $(INCLUDES)
 
 noinst_LIBRARIES = lib.a
 
-lib_a_SOURCES = memset.S memcpy.c strlen.c strcpy.c strcmp.S setjmp.S ieeefp.c
+lib_a_SOURCES = memset.S memcpy.c strlen.c strcpy.c strcmp.S setjmp.S ieeefp.c pthread_setcancelstate.c sleep.c usleep.c
 lib_a_CCASFLAGS=$(AM_CCASFLAGS)
 lib_a_CFLAGS=$(AM_CFLAGS)
 

--- a/newlib/libc/machine/riscv/Makefile.in
+++ b/newlib/libc/machine/riscv/Makefile.in
@@ -58,7 +58,8 @@ lib_a_AR = $(AR) $(ARFLAGS)
 lib_a_LIBADD =
 am_lib_a_OBJECTS = lib_a-memset.$(OBJEXT) lib_a-memcpy.$(OBJEXT) \
 	lib_a-strlen.$(OBJEXT) lib_a-strcpy.$(OBJEXT) lib_a-strcmp.$(OBJEXT) \
-	lib_a-setjmp.$(OBJEXT) lib_a-ieeefp.$(OBJEXT)
+	lib_a-setjmp.$(OBJEXT) lib_a-ieeefp.$(OBJEXT) lib_a-pthread_setcancelstate.$(OBJEXT) \
+	lib_a-sleep.$(OBJEXT) lib_a-usleep.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I. -I$(srcdir)
 depcomp =
@@ -186,7 +187,7 @@ AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
-lib_a_SOURCES = memset.S memcpy.c strlen.c strcmp.S strcpy.c setjmp.S ieeefp.c
+lib_a_SOURCES = memset.S memcpy.c strlen.c strcmp.S strcpy.c setjmp.S ieeefp.c pthread_setcancelstate.c sleep.c usleep.c
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
 ACLOCAL_AMFLAGS = -I ../../.. -I ../../../..
@@ -295,6 +296,25 @@ lib_a-ieeefp.o: ieeefp.c
 
 lib_a-ieeefp.obj: ieeefp.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-ieeefp.obj `if test -f 'ieeefp.c'; then $(CYGPATH_W) 'ieeefp.c'; else $(CYGPATH_W) '$(srcdir)/ieeefp.c'; fi`
+
+lib_a-pthread_setcancelstate.o: pthread_setcancelstate.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-pthread_setcancelstate.o `test -f 'pthread_setcancelstate.c' || echo '$(srcdir)/'`pthread_setcancelstate.c
+
+lib_a-pthread_setcancelstate.obj: pthread_setcancelstate.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-pthread_setcancelstate.obj `if test -f 'pthread_setcancelstate.c'; then $(CYGPATH_W) 'pthread_setcancelstate.c'; else $(CYGPATH_W) '$(srcdir)/pthread_setcancelstate.c'; fi`
+
+lib_a-sleep.o: sleep.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-sleep.o `test -f 'sleep.c' || echo '$(srcdir)/'`sleep.c
+
+lib_a-sleep.obj: sleep.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-sleep.obj `if test -f 'sleep.c'; then $(CYGPATH_W) 'sleep.c'; else $(CYGPATH_W) '$(srcdir)/sleep.c'; fi`
+
+lib_a-usleep.o: usleep.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-usleep.o `test -f 'usleep.c' || echo '$(srcdir)/'`usleep.c
+
+lib_a-usleep.obj: usleep.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-usleep.obj `if test -f 'usleep.c'; then $(CYGPATH_W) 'usleep.c'; else $(CYGPATH_W) '$(srcdir)/usleep.c'; fi`
+
 uninstall-info-am:
 
 ID: $(HEADERS) $(SOURCES) $(LISP) $(TAGS_FILES)

--- a/newlib/libc/machine/riscv/pthread_setcancelstate.c
+++ b/newlib/libc/machine/riscv/pthread_setcancelstate.c
@@ -1,0 +1,13 @@
+#include "weak_alias.h"
+
+/* This weak alias is needed because _POSIX_THREADS triggers 
+   _STDIO_WITH_THREAD_CANCELLATION_SUPPORT in libc/stdio/local.h which adds 
+   thread cancelation support. If running without pthreads, there is no need to 
+   worry about this. However, libpthread can override this weak alias if linked 
+   against. */
+int __pthread_setcancelstate(int state, int * oldstate)
+{
+  return 0;
+}
+
+weak_alias (__pthread_setcancelstate, pthread_setcancelstate)

--- a/newlib/libc/machine/riscv/sleep.c
+++ b/newlib/libc/machine/riscv/sleep.c
@@ -1,0 +1,21 @@
+/* copied from libc/posix/sleep.c - sleep function */
+
+/* Written 2000 by Werner Almesberger */
+
+#include <errno.h>
+#include <time.h>
+#include <unistd.h>
+#include "weak_alias.h"
+
+unsigned __sleep(unsigned seconds)
+{
+    struct timespec ts;
+
+    ts.tv_sec = seconds;
+    ts.tv_nsec = 0;
+    if (!nanosleep(&ts,&ts)) return 0;
+    if (errno == EINTR) return ts.tv_sec;
+    return -1;
+}
+
+weak_alias (__sleep, sleep)

--- a/newlib/libc/machine/riscv/usleep.c
+++ b/newlib/libc/machine/riscv/usleep.c
@@ -1,0 +1,21 @@
+/* copied from libc/posix/usleep.c - usleep function */
+
+/* Written 2002 by Jeff Johnston */
+
+#include <errno.h>
+#include <time.h>
+#include <unistd.h>
+#include "weak_alias.h"
+
+int __usleep(useconds_t useconds)
+{
+    struct timespec ts;
+
+    ts.tv_sec = (long int)useconds / 1000000;
+    ts.tv_nsec = ((long int)useconds % 1000000) * 1000;
+    if (!nanosleep(&ts,&ts)) return 0;
+    if (errno == EINTR) return ts.tv_sec;
+    return -1;
+}
+weak_alias (__usleep, usleep)
+

--- a/newlib/libc/machine/riscv/weak_alias.h
+++ b/newlib/libc/machine/riscv/weak_alias.h
@@ -1,0 +1,7 @@
+#ifndef __WEAK_ALIAS_H_
+#define __WEAK_ALIAS_H_
+
+#define weak_alias(name, aliasname) \
+  extern __typeof (name) aliasname __attribute__ ((__weak__, __alias__ (#name)));
+
+#endif /* __WEAK_ALIAS_H_ */

--- a/newlib/newlib.hin
+++ b/newlib/newlib.hin
@@ -12,6 +12,9 @@
 /* Newlib version */
 #include <_newlib_version.h>
 
+/* pthreads support in header files for newlib */
+#undef _WANT_RISCV_PTHREADS
+
 /* C99 formats support (such as %a, %zu, ...) in IO functions like
  * printf/scanf enabled */
 #undef _WANT_IO_C99_FORMATS


### PR DESCRIPTION
Added optional support for external pthreads library via --enable-riscv-pthreads.

All #defines are in sys/features.h.
Moved sleep/usleep into machine/riscv so they can be used without the rest of the posix folder.
pthread_setcancelstate is required because _POSIX_THREADS triggers cancelation in some stdio functions.