### PR TITLE
Fixed return code in _times syscall.

### DIFF
--- a/libgloss/riscv/sys_times.c
+++ b/libgloss/riscv/sys_times.c
@@ -33,5 +33,5 @@ _times(struct tms *buf)
   buf->tms_utime = utime * CLOCKS_PER_SEC / 1000000;
   buf->tms_stime = buf->tms_cstime = buf->tms_cutime = 0;
 
-  return 0;
+  return buf->tms_utime;
 }

--- a/libgloss/riscv/sys_times.c
+++ b/libgloss/riscv/sys_times.c
@@ -23,7 +23,7 @@ _times(struct tms *buf)
 {
   // when called for the first time, initialize t0
   static struct timeval t0;
-  if (t0.tv_sec == 0)
+  if (t0.tv_sec == 0 && t0.tv_usec == 0)
     _gettimeofday (&t0, 0);
 
   struct timeval t;
@@ -33,5 +33,5 @@ _times(struct tms *buf)
   buf->tms_utime = utime * CLOCKS_PER_SEC / 1000000;
   buf->tms_stime = buf->tms_cstime = buf->tms_cutime = 0;
 
-  return -1;
+  return 0;
 }


### PR DESCRIPTION
In success case syscall returns zero.