### PR TITLE
Relaxed error condition in syscall handler.

### DIFF
--- a/libgloss/riscv/internal_syscall.h
+++ b/libgloss/riscv/internal_syscall.h
@@ -40,7 +40,8 @@ __internal_syscall(long n, long _a0, long _a1, long _a2, long _a3, long _a4, lon
   asm volatile ("scall"
 		: "+r"(a0) : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5), "r"(syscall_id));
 
-  if (a0 < 0)
+  // Syscall _sbrk may use negative a0 (ex.: 32-bit system with DRAM base >= 0x80000000).
+  if (a0 < 0 && a0 > -__ELASTERROR)
     return __syscall_error (a0);
   else
     return a0;

--- a/libgloss/riscv/internal_syscall.h
+++ b/libgloss/riscv/internal_syscall.h
@@ -40,14 +40,18 @@ __internal_syscall(long n, long _a0, long _a1, long _a2, long _a3, long _a4, lon
   asm volatile ("scall"
 		: "+r"(a0) : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5), "r"(syscall_id));
 
-  // Syscall _sbrk may use negative a0 (ex.: 32-bit system with DRAM base >= 0x80000000).
-  if (a0 < 0 && a0 > -__ELASTERROR)
+  return a0;
+}
+
+static inline long
+syscall_errno(long n, long _a0, long _a1, long _a2, long _a3, long _a4, long _a5)
+{
+  register long a0 asm("a0") = __internal_syscall (n, _a0, _a1, _a2, _a3, _a4, _a5);
+
+  if (a0 < 0)
     return __syscall_error (a0);
   else
     return a0;
 }
-
-#define syscall_errno(n, a, b, c, d, e, f) \
-        __internal_syscall(n, (long)(a), (long)(b), (long)(c), (long)(d), (long)(e), (long)(f))
 
 #endif

--- a/libgloss/riscv/sys_sbrk.c
+++ b/libgloss/riscv/sys_sbrk.c
@@ -41,14 +41,14 @@ _sbrk(ptrdiff_t incr)
 
   if (heap_end == 0)
     {
-      long brk = syscall_errno (SYS_brk, 0, 0, 0, 0, 0, 0);
+      long brk = __internal_syscall (SYS_brk, 0, 0, 0, 0, 0, 0);
       if (brk == -1)
-	return (void *)-1;
+        return (void *)__syscall_error (ENOMEM);
       heap_end = brk;
     }
 
-  if (syscall_errno (SYS_brk, heap_end + incr, 0, 0, 0, 0, 0) != heap_end + incr)
-    return (void *)-1;
+  if (__internal_syscall (SYS_brk, heap_end + incr, 0, 0, 0, 0, 0) != heap_end + incr)
+    return (void *)__syscall_error (ENOMEM);
 
   heap_end += incr;
   return (void *)(heap_end - incr);

--- a/libgloss/riscv/sys_sbrk.c
+++ b/libgloss/riscv/sys_sbrk.c
@@ -43,12 +43,12 @@ _sbrk(ptrdiff_t incr)
     {
       long brk = __internal_syscall (SYS_brk, 0, 0, 0, 0, 0, 0);
       if (brk == -1)
-        return (void *)__syscall_error (ENOMEM);
+        return (void *)__syscall_error (-ENOMEM);
       heap_end = brk;
     }
 
   if (__internal_syscall (SYS_brk, heap_end + incr, 0, 0, 0, 0, 0) != heap_end + incr)
-    return (void *)__syscall_error (ENOMEM);
+    return (void *)__syscall_error (-ENOMEM);
 
   heap_end += incr;
   return (void *)(heap_end - incr);


### PR DESCRIPTION
Errno has range from -1 to -__ELASTERROR. Another values in a0 should be
bypassed.